### PR TITLE
Fix the individual id validation for rid check status api

### DIFF
--- a/resident/resident-service/src/main/java/io/mosip/resident/controller/ResidentController.java
+++ b/resident/resident-service/src/main/java/io/mosip/resident/controller/ResidentController.java
@@ -77,7 +77,7 @@ public class ResidentController {
 	public ResponseWrapper<RegStatusCheckResponseDTO> getRidStatus(
 			@Valid @RequestBody RequestWrapper<RequestDTO> requestDTO) throws ApisResourceAccessException {
 		audit.setAuditRequestDto(EventEnum.getEventEnumWithValue(EventEnum.VALIDATE_REQUEST, "get Rid status API"));
-		validator.validateRequestDTO(requestDTO);
+		validator.validateRidCheckStatusRequestDTO(requestDTO);
 		ResponseWrapper<RegStatusCheckResponseDTO> response = new ResponseWrapper<>();
 		audit.setAuditRequestDto(EventEnum.RID_STATUS);
 		response.setResponse(residentService.getRidStatus(requestDTO.getRequest()));

--- a/resident/resident-service/src/main/java/io/mosip/resident/validator/RequestValidator.java
+++ b/resident/resident-service/src/main/java/io/mosip/resident/validator/RequestValidator.java
@@ -534,7 +534,7 @@ public class RequestValidator {
 
 	}
 
-	public void validateRequestDTO(RequestWrapper<RequestDTO> requestDTO) {
+	public void validateRidCheckStatusRequestDTO(RequestWrapper<RequestDTO> requestDTO) {
 		validateRequest(requestDTO, RequestIdType.CHECK_STATUS);
 
 		if (requestDTO.getRequest() == null) {
@@ -548,8 +548,7 @@ public class RequestValidator {
 					EventEnum.getEventEnumWithValue(EventEnum.INPUT_INVALID, "individual type", "get RID status"));
 			throw new InvalidInputException("individualIdType");
 		}
-		if (StringUtils.isEmpty(requestDTO.getRequest().getIndividualId())
-				|| (!validateIndividualIdvIdWithoutIdType(requestDTO.getRequest().getIndividualId()))) {
+		if (StringUtils.isEmpty(requestDTO.getRequest().getIndividualId())) {
 			audit.setAuditRequestDto(
 					EventEnum.getEventEnumWithValue(EventEnum.INPUT_INVALID, "individual Id", "get RID status"));
 			throw new InvalidInputException("individualId");

--- a/resident/resident-service/src/test/java/io/mosip/resident/test/validator/RequestValidatorTest.java
+++ b/resident/resident-service/src/test/java/io/mosip/resident/test/validator/RequestValidatorTest.java
@@ -595,7 +595,7 @@ public class RequestValidatorTest {
 		RequestWrapper<RequestDTO> requestWrapper = new RequestWrapper<>();
 		requestWrapper.setRequesttime(DateUtils.getUTCCurrentDateTimeString(pattern));
 		requestWrapper.setRequest(requestDTO);
-		requestValidator.validateRequestDTO(requestWrapper);
+		requestValidator.validateRidCheckStatusRequestDTO(requestWrapper);
 
 	}
 
@@ -608,7 +608,7 @@ public class RequestValidatorTest {
 		requestWrapper.setId("mosip.resident.checkstatus");
 		requestWrapper.setVersion("v1");
 		requestWrapper.setRequest(requestDTO);
-		requestValidator.validateRequestDTO(requestWrapper);
+		requestValidator.validateRidCheckStatusRequestDTO(requestWrapper);
 
 	}
 
@@ -623,7 +623,7 @@ public class RequestValidatorTest {
 		requestWrapper.setId("mosip.resident.checkstatus");
 		requestWrapper.setVersion("v1");
 		requestWrapper.setRequest(requestDTO);
-		requestValidator.validateRequestDTO(requestWrapper);
+		requestValidator.validateRidCheckStatusRequestDTO(requestWrapper);
 
 	}
 


### PR DESCRIPTION
Since rid-check status needs to support RID also, there is not need for invoking the individual ID validation as in existing logic if it is not UIN / VID it is accepted as RID, which is not needed to verify.