### PR TITLE
MOSIP-33173 Updated the POM version and apitest-commons version

### DIFF
--- a/apitest/pom.xml
+++ b/apitest/pom.xml
@@ -8,7 +8,7 @@
 	<name>apitest-resident</name>
 	<description>Parent project of apitest-resident</description>
 	<url>https://github.com/mosip/resident-services</url>
-	<version>1.2.0.1-SNAPSHOT</version>
+	<version>1.2.1-SNAPSHOT</version>
 
 	<licenses>
 		<license>
@@ -388,7 +388,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apirig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-			<version>1.2.0.1-SNAPSHOT</version>
+			<version>1.2.1-SNAPSHOT</version>
 		</dependency>
 		
 	</dependencies>


### PR DESCRIPTION
Updated the POM version as 1.2.1-SNAPSHOT and apitest-commons version as 1.2.1-SNAPSHOT with respect to module wise api testrig.