### PR TITLE
MOSIP-36012 - Added mountPathForReport property in kernel

### DIFF
--- a/apitest/src/main/resources/config/Kernel.properties
+++ b/apitest/src/main/resources/config/Kernel.properties
@@ -261,6 +261,7 @@ admin_userName=220005
 admin_zone_password=mosip123
 admin_zone_userName=globaladmin
 mockNotificationChannel=email,phone
+mountPathForReport=/home/mosip/testrig/report
 
 
 #------------------------- Need to check if these are used or not ------------------------#


### PR DESCRIPTION
MOSIP-36012 - Added mountPathForReport property in kernel