### PR TITLE
MOSIP-38542 - Removed the logic of fetching phone regex from actuator. As the bug is fixed from server side

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/resident/testscripts/AddIdentity.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/resident/testscripts/AddIdentity.java
@@ -111,12 +111,7 @@ public class AddIdentity extends AdminTestUtil implements ITest {
 		inputJson = inputJson.replace("$RID$", genRid);
 		String phoneNumber = "";
 		String email = testCaseName +"@mosip.net";
-		if (inputJson.contains("$PHONENUMBERFORIDENTITY$")) {
-			
-			// MOSIP-34689 - UI spec has invalid regex till that is fixed from server end. get regex properties from resident actuator.
-			
-			phoneSchemaRegex = getValueFromActuator(GlobalConstants.RESIDENT_DEFAULT_PROPERTIES, "mosip.id.validation.identity.phone");
-			
+		if (inputJson.contains("$PHONENUMBERFORIDENTITY$")) {			
 			if (!phoneSchemaRegex.isEmpty())
 				try {
 					phoneNumber = genStringAsperRegex(phoneSchemaRegex);


### PR DESCRIPTION
Removed the code that fetched the phone regex from the actuator, as the server-side bug has been fixed. We are now fetching the phone regex from the default schema for UIN generation.