### PR TITLE
MOSIP-40544 - Removed SNAPSHOT for apitest commons in POM

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -56,7 +56,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-			<version>1.3.1-SNAPSHOT</version>
+			<version>1.3.1</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
MOSIP-40544 - Removed SNAPSHOT for apitest commons in POM