### PR TITLE
MOSIP-28246: Removed unused variables from resident module

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/resident/testscripts/AuditValidator.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/resident/testscripts/AuditValidator.java
@@ -2,7 +2,7 @@ package io.mosip.testrig.apirig.resident.testscripts;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.Arrays;
+//import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/api-test/src/main/java/io/mosip/testrig/apirig/resident/testscripts/PatchWithBodyWithOtpGenerate.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/resident/testscripts/PatchWithBodyWithOtpGenerate.java
@@ -26,7 +26,7 @@ import io.mosip.testrig.apirig.resident.utils.ResidentUtil;
 import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 import io.mosip.testrig.apirig.testrunner.HealthChecker;
 import io.mosip.testrig.apirig.utils.AdminTestException;
-import io.mosip.testrig.apirig.utils.AdminTestUtil;
+//import io.mosip.testrig.apirig.utils.AdminTestUtil;
 import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;

--- a/api-test/src/main/java/io/mosip/testrig/apirig/resident/testscripts/PostWithAutogenIdWithOtpGenerate.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/resident/testscripts/PostWithAutogenIdWithOtpGenerate.java
@@ -27,7 +27,7 @@ import io.mosip.testrig.apirig.resident.utils.ResidentUtil;
 import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 import io.mosip.testrig.apirig.testrunner.HealthChecker;
 import io.mosip.testrig.apirig.utils.AdminTestException;
-import io.mosip.testrig.apirig.utils.AdminTestUtil;
+//import io.mosip.testrig.apirig.utils.AdminTestUtil;
 import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
@@ -98,7 +98,7 @@ public class PostWithAutogenIdWithOtpGenerate extends ResidentUtil implements IT
 				throw new SkipException(GlobalConstants.VID_FEATURE_NOT_SUPPORTED);
 			}
 		}
-		String inputJson = testCaseDTO.getInput().toString();
+//		String inputJson = testCaseDTO.getInput().toString();
 		JSONObject req = new JSONObject(testCaseDTO.getInput());
 
 		auditLogCheck = testCaseDTO.isAuditLogCheck();

--- a/api-test/src/main/java/io/mosip/testrig/apirig/resident/testscripts/PostWithBodyWithOtpGenerate.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/resident/testscripts/PostWithBodyWithOtpGenerate.java
@@ -26,7 +26,7 @@ import io.mosip.testrig.apirig.resident.utils.ResidentUtil;
 import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 import io.mosip.testrig.apirig.testrunner.HealthChecker;
 import io.mosip.testrig.apirig.utils.AdminTestException;
-import io.mosip.testrig.apirig.utils.AdminTestUtil;
+//import io.mosip.testrig.apirig.utils.AdminTestUtil;
 import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
@@ -94,7 +94,7 @@ public class PostWithBodyWithOtpGenerate extends ResidentUtil implements ITest {
 			}
 		}
 		auditLogCheck = testCaseDTO.isAuditLogCheck();
-		String tempUrl = ResidentConfigManager.getEsignetBaseUrl();
+//		String tempUrl = ResidentConfigManager.getEsignetBaseUrl();
 		JSONObject req = new JSONObject(testCaseDTO.getInput());
 		String otpRequest = null;
 		String sendOtpReqTemplate = null;

--- a/api-test/src/main/java/io/mosip/testrig/apirig/resident/testscripts/PostWithParamAndFile.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/resident/testscripts/PostWithParamAndFile.java
@@ -27,7 +27,7 @@ import io.mosip.testrig.apirig.resident.utils.ResidentUtil;
 import io.mosip.testrig.apirig.testrunner.BaseTestCase;
 import io.mosip.testrig.apirig.testrunner.HealthChecker;
 import io.mosip.testrig.apirig.utils.AdminTestException;
-import io.mosip.testrig.apirig.utils.AdminTestUtil;
+//import io.mosip.testrig.apirig.utils.AdminTestUtil;
 import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;

--- a/api-test/src/main/java/io/mosip/testrig/apirig/resident/testscripts/SimplePostForAutoGenId.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/resident/testscripts/SimplePostForAutoGenId.java
@@ -107,7 +107,7 @@ public class SimplePostForAutoGenId extends ResidentUtil implements ITest {
 		
 		inputJson = ResidentUtil.inputstringKeyWordHandeler(inputJson, testCaseName);
 
-		String outputJson = getJsonFromTemplate(testCaseDTO.getOutput(), testCaseDTO.getOutputTemplate());
+//		String outputJson = getJsonFromTemplate(testCaseDTO.getOutput(), testCaseDTO.getOutputTemplate());
 
 		if (testCaseDTO.getTemplateFields() != null && templateFields.length > 0) {
 			ArrayList<JSONObject> inputtestCases = AdminTestUtil.getInputTestCase(testCaseDTO);


### PR DESCRIPTION
Commented out unused variables in the resident module to improve code cleanliness and maintainability. Identified via static code analysis. No functional changes made.

