### PR TITLE
MOSIP-33663: Added Negative testcases For Invalid UIN and VID in sendOTP.

### DIFF
--- a/api-test/pom.xml
+++ b/api-test/pom.xml
@@ -69,7 +69,7 @@
 		<dependency>
 			<groupId>io.mosip.testrig.apitest.commons</groupId>
 			<artifactId>apitest-commons</artifactId>
-			<version>1.4.0-SNAPSHOT</version>
+			<version>1.5.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 	<distributionManagement>

--- a/api-test/src/main/java/io/mosip/testrig/apirig/resident/testscripts/PostWithBodyWithOtpGenerateAndPdfDownload.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/resident/testscripts/PostWithBodyWithOtpGenerateAndPdfDownload.java
@@ -3,12 +3,15 @@ package io.mosip.testrig.apirig.resident.testscripts;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.json.JSONObject;
+import org.testng.Assert;
 import org.testng.ITest;
 import org.testng.ITestContext;
 import org.testng.ITestResult;
@@ -137,24 +140,59 @@ public class PostWithBodyWithOtpGenerateAndPdfDownload extends ResidentUtil impl
 		pdf = postWithBodyAndCookieForPdf(ApplnURI + testCaseDTO.getEndPoint(),
 				getJsonFromTemplate(testCaseDTO.getInput(), testCaseDTO.getInputTemplate()), COOKIENAME,
 				testCaseDTO.getRole(), testCaseDTO.getTestCaseName());
+		
+		// Check if response is empty
+		if (pdf == null || pdf.length == 0) {
+		    Assert.fail("UIN card download failed: response is empty");
+		}
+		
+		// Check if response is JSON (API error)
+		String responseString = new String(pdf);
+
+		// Check if it starts with { → it's JSON (probably an error)
+		if (responseString.trim().startsWith("{")) {
+		    JSONObject json = new JSONObject(responseString);  // parse JSON
+		    
+		    GlobalMethods.reportResponse(null, ApplnURI + testCaseDTO.getEndPoint(), json.toString(2));
+
+		    // If JSON contains "errors", fail the test
+		    if (json.has("errors")) {
+		        Assert.fail("UIN card download failed: " + json.getJSONArray("errors").toString());
+		    } else {
+		        Assert.fail("UIN card download failed: unexpected JSON response");
+		    }
+		}
+		
+		// Check PDF header (%PDF)
+		String pdfHeader = new String(Arrays.copyOfRange(pdf, 0, 4), StandardCharsets.UTF_8);
+		if (!pdfHeader.equals("%PDF")) {
+		    Assert.fail("UIN card download failed: invalid PDF header");
+		}
+		
 		PdfReader pdfReader = null;
 		ByteArrayInputStream bIS = null;
+		String pdfAsText = null;
 
 		try {
+			
+			String password = "TEST1992";
+			
 			bIS = new ByteArrayInputStream(pdf);
-			pdfReader = new PdfReader(bIS);
+			pdfReader = new PdfReader(bIS, password.getBytes(StandardCharsets.UTF_8));
 			pdfAsText = PdfTextExtractor.getTextFromPage(pdfReader, 1);
+			
+			// Check if PDF content is empty
+		    if (pdfAsText == null || pdfAsText.isEmpty()) {
+		        Assert.fail("UIN card download failed: PDF is empty or unreadable");
+		    }
+		    
+		    GlobalMethods.reportResponse(null, ApplnURI + testCaseDTO.getEndPoint(), pdfAsText);
+
 		} catch (IOException e) {
-			Reporter.log("Exception : " + e.getMessage());
+			Assert.fail("Exception while reading PDF: " + e.getMessage());
 		} finally {
 			AdminTestUtil.closeByteArrayInputStream(bIS);
 			AdminTestUtil.closePdfReader(pdfReader);
-		}
-
-		if (pdf != null && (new String(pdf).contains("errors") || pdfAsText == null)) {
-			GlobalMethods.reportResponse(null, ApplnURI + testCaseDTO.getEndPoint(), "Not able to download UIN Card");
-		} else {
-			GlobalMethods.reportResponse(null, ApplnURI + testCaseDTO.getEndPoint(), pdfAsText);
 		}
 
 	}

--- a/api-test/src/main/java/io/mosip/testrig/apirig/resident/testscripts/PostWithBodyWithOtpGenerateAndPdfDownload.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/resident/testscripts/PostWithBodyWithOtpGenerateAndPdfDownload.java
@@ -3,15 +3,12 @@ package io.mosip.testrig.apirig.resident.testscripts;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.json.JSONObject;
-import org.testng.Assert;
 import org.testng.ITest;
 import org.testng.ITestContext;
 import org.testng.ITestResult;
@@ -140,59 +137,24 @@ public class PostWithBodyWithOtpGenerateAndPdfDownload extends ResidentUtil impl
 		pdf = postWithBodyAndCookieForPdf(ApplnURI + testCaseDTO.getEndPoint(),
 				getJsonFromTemplate(testCaseDTO.getInput(), testCaseDTO.getInputTemplate()), COOKIENAME,
 				testCaseDTO.getRole(), testCaseDTO.getTestCaseName());
-		
-		// Check if response is empty
-		if (pdf == null || pdf.length == 0) {
-		    Assert.fail("UIN card download failed: response is empty");
-		}
-		
-		// Check if response is JSON (API error)
-		String responseString = new String(pdf);
-
-		// Check if it starts with { → it's JSON (probably an error)
-		if (responseString.trim().startsWith("{")) {
-		    JSONObject json = new JSONObject(responseString);  // parse JSON
-		    
-		    GlobalMethods.reportResponse(null, ApplnURI + testCaseDTO.getEndPoint(), json.toString(2));
-
-		    // If JSON contains "errors", fail the test
-		    if (json.has("errors")) {
-		        Assert.fail("UIN card download failed: " + json.getJSONArray("errors").toString());
-		    } else {
-		        Assert.fail("UIN card download failed: unexpected JSON response");
-		    }
-		}
-		
-		// Check PDF header (%PDF)
-		String pdfHeader = new String(Arrays.copyOfRange(pdf, 0, 4), StandardCharsets.UTF_8);
-		if (!pdfHeader.equals("%PDF")) {
-		    Assert.fail("UIN card download failed: invalid PDF header");
-		}
-		
 		PdfReader pdfReader = null;
 		ByteArrayInputStream bIS = null;
-		String pdfAsText = null;
 
 		try {
-			
-			String password = "TEST1992";
-			
 			bIS = new ByteArrayInputStream(pdf);
-			pdfReader = new PdfReader(bIS, password.getBytes(StandardCharsets.UTF_8));
+			pdfReader = new PdfReader(bIS);
 			pdfAsText = PdfTextExtractor.getTextFromPage(pdfReader, 1);
-			
-			// Check if PDF content is empty
-		    if (pdfAsText == null || pdfAsText.isEmpty()) {
-		        Assert.fail("UIN card download failed: PDF is empty or unreadable");
-		    }
-		    
-		    GlobalMethods.reportResponse(null, ApplnURI + testCaseDTO.getEndPoint(), pdfAsText);
-
 		} catch (IOException e) {
-			Assert.fail("Exception while reading PDF: " + e.getMessage());
+			Reporter.log("Exception : " + e.getMessage());
 		} finally {
 			AdminTestUtil.closeByteArrayInputStream(bIS);
 			AdminTestUtil.closePdfReader(pdfReader);
+		}
+
+		if (pdf != null && (new String(pdf).contains("errors") || pdfAsText == null)) {
+			GlobalMethods.reportResponse(null, ApplnURI + testCaseDTO.getEndPoint(), "Not able to download UIN Card");
+		} else {
+			GlobalMethods.reportResponse(null, ApplnURI + testCaseDTO.getEndPoint(), pdfAsText);
 		}
 
 	}

--- a/api-test/src/main/resources/resident/SendOTP/SendOTP.yml
+++ b/api-test/src/main/resources/resident/SendOTP/SendOTP.yml
@@ -363,3 +363,75 @@ SendOTP:
 }'
       output: '{
     }'
+
+   Resident_SendOTP_With_Invalid_UIN_Neg:
+      endPoint: /resident/v1/req/otp
+      uniqueIdentifier: TC_Resident_Sendotp_21      
+      description: Request otp using invalid UIN as individualId   
+      role: resident
+      restMethod: post
+      inputTemplate: resident/SendOTP/createSendOTP
+      outputTemplate: resident/SendOTP/createSendOTPErrorResult
+      input: '{
+    "transactionID": "$TRANSACTIONID$",
+    "requestTime": "$TIMESTAMP$",
+    "individualId": "$INVALID_UIN$",
+    "individualIdType": "UIN"
+}'
+      output: '{
+         "errorCode": "IDA-MLC-009"
+    }'
+
+   Resident_SendOTP_With_Valid_UIN_NotIn_DB_Neg:
+      endPoint: /resident/v1/req/otp
+      uniqueIdentifier: TC_Resident_Sendotp_22      
+      description: Request otp using valid UIN but not present in db  
+      role: resident
+      restMethod: post
+      inputTemplate: resident/SendOTP/createSendOTP
+      outputTemplate: resident/SendOTP/createSendOTPErrorResult
+      input: '{
+    "transactionID": "$TRANSACTIONID$",
+    "requestTime": "$TIMESTAMP$",
+    "individualId": "$VALID_UIN_NOTIN_DB$",
+    "individualIdType": "UIN"
+}'
+      output: '{
+         "errorCode": "IDA-MLC-018"
+    }'
+
+   Resident_SendOTP_With_Invalid_VID_Neg:
+      endPoint: /resident/v1/req/otp
+      uniqueIdentifier: TC_Resident_Sendotp_23     
+      description: Request otp using invalid VID as individualId   
+      role: resident
+      restMethod: post
+      inputTemplate: resident/SendOTP/createSendOTP
+      outputTemplate: resident/SendOTP/createSendOTPErrorResult
+      input: '{
+    "transactionID": "$TRANSACTIONID$",
+    "requestTime": "$TIMESTAMP$",
+    "individualId": "$INVALID_VID$",
+    "individualIdType": "VID"
+}'
+      output: '{
+         "errorCode": "IDA-MLC-009"
+    }'
+
+   Resident_SendOTP_With_Valid_VID_NotIn_DB_Neg:
+      endPoint: /resident/v1/req/otp
+      uniqueIdentifier: TC_Resident_Sendotp_24     
+      description: Request otp using valid VID but not present in db  
+      role: resident
+      restMethod: post
+      inputTemplate: resident/SendOTP/createSendOTP
+      outputTemplate: resident/SendOTP/createSendOTPErrorResult
+      input: '{
+    "transactionID": "$TRANSACTIONID$",
+    "requestTime": "$TIMESTAMP$",
+    "individualId": "$VALID_VID_NOTIN_DB$",
+    "individualIdType": "VID"
+}'
+      output: '{
+         "errorCode": "IDA-MLC-018"
+    }'


### PR DESCRIPTION
Added negative test cases for invalid UIN and VID in Send OTP, since the Generate VID API depends on Send OTP execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added five new negative test scenarios for SendOTP API, validating error handling for invalid UINs, invalid VIDs, and cases where valid identifiers are not found in the database.

* **Chores**
  * Updated transitive dependency version to latest snapshot release.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->