### PR TITLE
MOSIP-44709: Fixed HealthCheck module mapping by using normalized module name instead of prefixed identifier.

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/resident/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/resident/testrunner/MosipTestRunner.java
@@ -102,7 +102,7 @@ public class MosipTestRunner {
 			setLogLevels();
 
 			HealthChecker healthcheck = new HealthChecker();
-			healthcheck.setCurrentRunningModule(BaseTestCase.currentModule);
+			healthcheck.setCurrentRunningModule(GlobalConstants.RESIDENT);
 			Thread trigger = new Thread(healthcheck);
 			trigger.start();
 			


### PR DESCRIPTION
Fixes HealthCheck module mismatch by replacing the prefixed module name (BaseTestCase.currentModule) with a normalized value (GlobalConstants.RESIDENT), ensuring correct mapping with healthCheckEndpoint.properties and proper endpoint filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated module context initialization for health monitoring to ensure consistent runtime configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->