### PR TITLE
[BUG-FIX] Fix hardcoded password and no-op grant in 1.1.5.5_to_1.2.0.1-B1_upgrade.sql

### DIFF
--- a/db_upgrade_scripts/mosip_resident/sql/1.1.5.5_to_1.2.0.1-B1_upgrade.sql
+++ b/db_upgrade_scripts/mosip_resident/sql/1.1.5.5_to_1.2.0.1-B1_upgrade.sql
@@ -15,10 +15,10 @@ CREATE SCHEMA resident;
 ALTER SCHEMA resident OWNER TO postgres;
 ALTER DATABASE mosip_resident SET search_path TO resident,pg_catalog,public;
 
-CREATE ROLE residentuser WITH 
+CREATE ROLE residentuser WITH
 	INHERIT
 	LOGIN
-	PASSWORD 'dbuserpwd';
+	PASSWORD :dbuserpwd;
 
 GRANT CONNECT
    ON DATABASE mosip_resident
@@ -28,9 +28,8 @@ GRANT USAGE
    ON SCHEMA resident
    TO residentuser;
 
-GRANT SELECT,INSERT,UPDATE,DELETE,REFERENCES
-   ON ALL TABLES IN SCHEMA resident
-   TO residentuser;
+ALTER DEFAULT PRIVILEGES IN SCHEMA resident
+   GRANT SELECT,INSERT,UPDATE,DELETE,REFERENCES ON TABLES TO residentuser;
 
 -- This Table is used to save the OTP for the user whenever user requests for one using the email id / phone number to log into the application.
 CREATE TABLE resident.otp_transaction(


### PR DESCRIPTION
## Summary

- Reverts `PASSWORD 'dbuserpwd'` back to `PASSWORD :dbuserpwd` so the password is correctly substituted from `upgrade.properties` at runtime (regression introduced in #1207)
- Replaces `GRANT SELECT,INSERT,UPDATE,DELETE,REFERENCES ON ALL TABLES IN SCHEMA resident` (no-op — runs before any tables exist) with `ALTER DEFAULT PRIVILEGES IN SCHEMA resident GRANT ... ON TABLES TO residentuser`

## Root Cause

PR #1207 (MOSIP-31951) changed the psql variable `:dbuserpwd` to the hardcoded literal `'dbuserpwd'`, causing all deployments to set the `residentuser` password to the literal string `dbuserpwd` regardless of what is configured in `upgrade.properties`.

## Test Plan

- [ ] Run `upgrade.sh` with a custom `DBUSER_PWD` in `upgrade.properties` and verify `residentuser` is created with the correct password
- [ ] Verify all 5 tables are created with correct grants for `residentuser`
- [ ] Verify `ALTER DEFAULT PRIVILEGES` applies to all tables in the `resident` schema

## References

- Bug issue: https://github.com/mosip/resident-services/issues/1635
- Regression introduced in: #1207

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Updated the database upgrade process to use parameterized password placeholders instead of embedding credentials directly.
* **Chores**
  * Improved database permission setup by configuring default privileges so the required access is automatically applied to newly created schema objects (covering common DML and reference permissions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->