### PR TITLE
MOSIP-45314 Added jti and random nonce

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/resident/utils/ResidentUtil.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/resident/utils/ResidentUtil.java
@@ -170,6 +170,7 @@ public class ResidentUtil extends AdminTestUtil {
 			payloadBody.put("aud", esignetBaseURI);
 			payloadBody.put("exp", epochValue + idTokenExpirySecs);
 			payloadBody.put("iat", epochValue);
+			payloadBody.put("jti", java.util.UUID.randomUUID().toString());
 
 			jsonString = replaceKeywordValue(jsonString, "$IDPCLIENTPAYLOAD$",
 					encodeBase64(payloadBody.toString()));

--- a/api-test/src/main/resources/resident/OAuthDetailsRequest/OAuthDetailsRequest.yml
+++ b/api-test/src/main/resources/resident/OAuthDetailsRequest/OAuthDetailsRequest.yml
@@ -17,7 +17,7 @@ OAuthDetailsRequest:
       	"display": "popup",
 	    "prompt": "login",
 	    "acrValues": "mosip:idp:acr:generated-code",
-	    "nonce": "$RANDOMUUID$",
+	    "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
 	    "state": "$RANDOMUUID$",
 	    "claimsLocales": "en",
 	    "userinfo": "$CLAIMSFROMCONFIG$"
@@ -44,7 +44,7 @@ OAuthDetailsRequest:
       	"display": "popup",
 	    "prompt": "login",
 	    "acrValues": "mosip:idp:acr:generated-code",
-	    "nonce": "$RANDOMUUID$",
+	    "nonce": "$UNIQUENONCEVALUEFORESIGNET$",
 	    "state": "$RANDOMUUID$",
 	    "claimsLocales": "en",
 	    "userinfo": "$CLAIMSFROMCONFIG$"

--- a/api-test/src/main/resources/resident/OAuthDetailsRequest/OAuthDetailsRequest.yml
+++ b/api-test/src/main/resources/resident/OAuthDetailsRequest/OAuthDetailsRequest.yml
@@ -17,7 +17,7 @@ OAuthDetailsRequest:
       	"display": "popup",
 	    "prompt": "login",
 	    "acrValues": "mosip:idp:acr:generated-code",
-	    "nonce": "973eieljzng",
+	    "nonce": "$RANDOMUUID$",
 	    "state": "$RANDOMUUID$",
 	    "claimsLocales": "en",
 	    "userinfo": "$CLAIMSFROMCONFIG$"
@@ -44,7 +44,7 @@ OAuthDetailsRequest:
       	"display": "popup",
 	    "prompt": "login",
 	    "acrValues": "mosip:idp:acr:generated-code",
-	    "nonce": "973eieljzng",
+	    "nonce": "$RANDOMUUID$",
 	    "state": "$RANDOMUUID$",
 	    "claimsLocales": "en",
 	    "userinfo": "$CLAIMSFROMCONFIG$"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resident OAuth and eSignet smoke test reliability by switching from a fixed nonce to a dynamically generated value for each request.
  * Enhanced client payload generation by adding an additional unique token identifier into the payload content, improving consistency across authentication flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->